### PR TITLE
feat: add package-manager choice to CI workflows

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -29,7 +29,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v4
+      - uses: actions/labeler@v5
         with:
           repo-token: ${{ github.token }}
   conventional-commits:
@@ -37,8 +37,8 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
       - uses: beemojs/conventional-pr-action@v3
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/pre-commit-update.yaml
+++ b/.github/workflows/pre-commit-update.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - run: |
@@ -22,7 +22,7 @@ jobs:
             pre-commit run --all-files || true
           fi
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v8
         with:
           branch: update/pre-commit-hooks
           commit-message: 'chore(pre-commit): update pre-commit hooks'

--- a/.github/workflows/project-issue-automation.yaml
+++ b/.github/workflows/project-issue-automation.yaml
@@ -56,7 +56,7 @@ jobs:
     name: Add Issue to Project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.5.0
+      - uses: actions/add-to-project@v1
         with:
           project-url: >
             https://github.com/orgs/${{ github.repository_owner }}/projects/${{ inputs.project-id }}

--- a/.github/workflows/project-pr-automation.yaml
+++ b/.github/workflows/project-pr-automation.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
     steps:
-      - uses: actions/add-to-project@v0.5.0
+      - uses: actions/add-to-project@v1
         with:
           project-url: >
             https://github.com/orgs/${{ github.repository_owner }}/projects/${{ inputs.project-id }}
@@ -37,7 +37,7 @@ jobs:
     outputs:
       issues: ${{ steps.linked-issues.outputs.issues }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Get Linked Issues Action
         id: linked-issues
         uses: kin/gh-action-get-linked-issues@v2.0

--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -61,7 +61,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - id: version
         run: echo "version=v$(cat version.txt)" >> "$GITHUB_OUTPUT"
   generate-deployment:
@@ -74,7 +74,7 @@ jobs:
       pull-requests: read
       deployments: write
     steps:
-      - uses: chrnorm/deployment-action@releases/v2
+      - uses: chrnorm/deployment-action@v2
         name: Create GitHub deployment
         id: deployment
         with:
@@ -93,7 +93,7 @@ jobs:
     env:
       RELEASE_NAME: ${{ needs.get-version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to Docker registry
@@ -104,7 +104,7 @@ jobs:
           password: ${{ secrets.docker-password }}
       - name: Build and push
         id: build-and-push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: ${{ inputs.back-context }}
           pull: true
@@ -130,7 +130,7 @@ jobs:
       RELEASE_NAME: ${{ needs.get-version.outputs.version }}
       SENTRY_TOKEN: ${{ secrets.sentry-token }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to Docker registry
@@ -141,7 +141,7 @@ jobs:
           password: ${{ secrets.docker-password }}
       - name: Build and push
         id: build-and-push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: ${{ inputs.web-context }}
           pull: true
@@ -197,17 +197,17 @@ jobs:
       pull-requests: read
       deployments: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Update deployment status (success)
         if: ${{ needs.pre-release.result == 'success' }}
-        uses: chrnorm/deployment-status@releases/v2
+        uses: chrnorm/deployment-status@v2
         with:
           token: ${{ github.token }}
           state: success
           deployment-id: ${{ needs.generate-deployment.outputs.deployment_id }}
       - name: Create sentry release
         if: ${{ needs.pre-release.result == 'success' && inputs.deployment-projects }}
-        uses: getsentry/action-release@v1
+        uses: getsentry/action-release@v3
         env:
           RELEASE_NAME: ${{ needs.get-version.outputs.version }}
           SENTRY_URL: ${{ secrets.sentry-url }}
@@ -219,7 +219,7 @@ jobs:
           projects: ${{ inputs.deployment-projects }}
       - name: Update deployment status (failure)
         if: ${{ needs.pre-release.result != 'success' }}
-        uses: chrnorm/deployment-status@releases/v2
+        uses: chrnorm/deployment-status@v2
         with:
           token: ${{ github.token }}
           state: failure

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,15 +5,15 @@ name: Release
 on:
   workflow_call:
     inputs:
-      package-name:
-        type: string
-        required: true
       package-release-type:
         type: string
         default: simple
-      package-extra-files:
+      config-file:
         type: string
-        default: ''
+        default: .release-please-config.json
+      manifest-file:
+        type: string
+        default: .release-please-manifest.json
       deployment-url:
         type: string
         required: true
@@ -44,28 +44,14 @@ jobs:
       pull-requests: write
       deployments: write
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - uses: google-github-actions/release-please-action@v4
         id: release
         with:
           token: ${{ secrets.gh-token }}
-          release-type: ${{ inputs.package-release-type}}
-          package-name: ${{ inputs.package-name }}
-          extra-files: ${{ inputs.package-extra-files }}
-          changelog-types: >
-            [{"type":"feat","section":"Features","hidden":false},
-             {"type":"BREAKING CHANGE","section":"Breaking Changes","hidden":false},
-             {"type":"fix","section":"Bug Fixes","hidden":false},
-             {"type":"perf","section":"Performance","hidden":false},
-             {"type":"deps","section":"Dependencies","hidden":false},
-             {"type":"revert","section":"Reverts","hidden":false},
-             {"type":"docs","section":"Documentation","hidden":false},
-             {"type":"style","section":"Styles","hidden":false},
-             {"type":"refactor","section":"Code Refactoring","hidden":false},
-             {"type":"test","section":"Tests","hidden":false},
-             {"type":"build","section":"Build System","hidden":false},
-             {"type":"ci","section":"Continuous Integration","hidden":false},
-             {"type":"chore","section":"Miscellaneous","hidden":false}]
-      - uses: chrnorm/deployment-action@releases/v2
+          release-type: ${{ inputs.package-release-type }}
+          config-file: ${{ inputs.config-file }}
+          manifest-file: ${{ inputs.manifest-file }}
+      - uses: chrnorm/deployment-action@v2
         name: Create GitHub deployment
         if: ${{ steps.release.outputs.release_created }}
         with:
@@ -74,10 +60,10 @@ jobs:
           ref: ${{ github.sha }}
           initial-status: success
           environment: ${{ inputs.deployment-environment }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Create sentry release
         if: ${{ steps.release.outputs.release_created }}
-        uses: getsentry/action-release@v1
+        uses: getsentry/action-release@v3
         env:
           SENTRY_URL: ${{ secrets.sentry-url }}
           SENTRY_ORG: ${{ secrets.sentry-org }}

--- a/.github/workflows/test-app.yaml
+++ b/.github/workflows/test-app.yaml
@@ -17,6 +17,9 @@ on:
       core-lint:
         type: boolean
         default: true
+      package-manager:
+        type: string
+        default: yarn
 
 concurrency:
   group: tests-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -29,7 +32,7 @@ jobs:
     outputs:
       has-changes: ${{ steps.check.outputs.changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 100
       - uses: marceloprado/has-changed-path@v1.0.1
@@ -46,30 +49,24 @@ jobs:
         shell: bash
         working-directory: ./${{ inputs.working-directory }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+
+      - name: Install pnpm
+        if: ${{ inputs.package-manager == 'pnpm' }}
+        uses: pnpm/action-setup@v4
+
       - id: setup-node
         name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node-version }}
-          cache: yarn
-          cache-dependency-path: '**/yarn.lock'
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
-      - name: Yarn cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            "**/node_modules"
+          cache: ${{ inputs.package-manager }}
           # yamllint disable-line rule:line-length
-          key: node-modules-${{ runner.os }}-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('**/yarn.lock')
-            }}
-          restore-keys: |
-            node-modules-${{ runner.os }}-${{ steps.setup-node.outputs.node-version }}-
-            node-modules-${{ runner.os }}-
-      - name: Yarn install
-        run: yarn install --immutable
+          cache-dependency-path: ${{ inputs.package-manager == 'yarn' && '**/yarn.lock' || '**/pnpm-lock.yaml' }}
+
+      - name: Install dependencies
+        # yamllint disable-line rule:line-length
+        run: ${{ inputs.package-manager == 'yarn' && 'yarn install --immutable' || 'pnpm install --frozen-lockfile' }}
+
       - name: App lint
-        run: yarn app-lint
+        run: ${{ inputs.package-manager }} app-lint

--- a/.github/workflows/test-back.yaml
+++ b/.github/workflows/test-back.yaml
@@ -13,18 +13,20 @@ on:
         default: backend
       python-version:
         type: string
-        default: '3.11'
+        default: '3.13'
       pytest-extra-args:
         type: string
         default: --cov=api
       need-geolibs:
         type: boolean
         default: true
+      package-manager:
+        type: string
+        default: poetry
 
 concurrency:
   # yamllint disable-line rule:line-length
-  group: tests-${{ github.workflow }}-${{ inputs.working-directory }}-${{ github.head_ref || github.run_id
-    }}
+  group: tests-${{ github.workflow }}-${{ inputs.working-directory }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -34,7 +36,7 @@ jobs:
     outputs:
       has-changes: ${{ steps.check.outputs.changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 100
       - uses: marceloprado/has-changed-path@v1.0.1
@@ -50,6 +52,9 @@ jobs:
       run:
         shell: bash
         working-directory: ./${{ inputs.working-directory }}
+    env:
+      # yamllint disable-line rule:line-length
+      RUN_PREFIX: ${{ inputs.package-manager == 'poetry' && 'poetry run' || 'uv run' }}
     services:
       redis:
         image: redis
@@ -58,22 +63,30 @@ jobs:
         ports:
           - 6379:6379
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+
       - name: Install system deps
         if: ${{ inputs.need-geolibs }}
         run: sudo apt-get update && sudo apt-get install gdal-bin libsqlite3-mod-spatialite
+
+      # --- poetry path ---
       - name: Set up Python
+        if: ${{ inputs.package-manager == 'poetry' }}
         id: setup-python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.python-version }}
+
       - name: Install poetry
+        if: ${{ inputs.package-manager == 'poetry' }}
         run: |
           pipx install poetry
           poetry config virtualenvs.create true
           poetry config virtualenvs.in-project true
+
       - name: Load cached venv
-        uses: actions/cache@v3
+        if: ${{ inputs.package-manager == 'poetry' }}
+        uses: actions/cache@v5
         with:
           path: ${{ inputs.working-directory }}/.venv
           # yamllint disable-line rule:line-length
@@ -82,23 +95,43 @@ jobs:
           restore-keys: |
             back-venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-
             back-venv-${{ runner.os }}-
-      - name: Install dependencies
+
+      - name: Install dependencies (poetry)
+        if: ${{ inputs.package-manager == 'poetry' }}
         run: poetry install
+
+      # --- uv path ---
+      - name: Set up uv
+        if: ${{ inputs.package-manager == 'uv' }}
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: ${{ inputs.python-version }}
+          enable-cache: true
+
+      - name: Install dependencies (uv)
+        if: ${{ inputs.package-manager == 'uv' }}
+        run: uv sync --locked
+
+      # --- shared steps ---
       - name: Check for ruff errors
-        run: poetry run ruff check .
+        run: $RUN_PREFIX ruff check .
+
       - name: Check for ruff format errors
-        run: poetry run ruff format --check .
+        run: $RUN_PREFIX ruff format --check .
+
       - name: Check for pyright errors
-        uses: jakebailey/pyright-action@v1
+        uses: jakebailey/pyright-action@v2
         with:
           working-directory: ${{ inputs.working-directory }}
+
       - name: Run Tests
         env:
           PYTEST_ARGS: ${{ inputs.pytest-extra-args }}
         # yamllint disable-line rule:line-length
-        run: poetry run pytest --junitxml=pytest.xml "${PYTEST_ARGS}" . | tee pytest-coverage.txt
+        run: $RUN_PREFIX pytest --junitxml=pytest.xml "${PYTEST_ARGS}" . | tee pytest-coverage.txt
+
       - name: Pytest coverage comment
-        uses: MishaKav/pytest-coverage-comment@main
+        uses: MishaKav/pytest-coverage-comment@v1
         if: ${{ github.actor != 'dependabot[bot]' }}
         continue-on-error: true
         with:

--- a/.github/workflows/test-web.yaml
+++ b/.github/workflows/test-web.yaml
@@ -17,6 +17,9 @@ on:
       core-lint:
         type: boolean
         default: true
+      package-manager:
+        type: string
+        default: yarn
 
 concurrency:
   group: tests-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -29,7 +32,7 @@ jobs:
     outputs:
       has-changes: ${{ steps.check.outputs.changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 100
       - uses: marceloprado/has-changed-path@v1.0.1
@@ -46,33 +49,28 @@ jobs:
         shell: bash
         working-directory: ./${{ inputs.working-directory }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+
+      - name: Install pnpm
+        if: ${{ inputs.package-manager == 'pnpm' }}
+        uses: pnpm/action-setup@v4
+
       - id: setup-node
         name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node-version }}
-          cache: yarn
-          cache-dependency-path: '**/yarn.lock'
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
-      - name: Yarn cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            "**/node_modules"
+          cache: ${{ inputs.package-manager }}
           # yamllint disable-line rule:line-length
-          key: node-modules-${{ runner.os }}-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('**/yarn.lock')
-            }}
-          restore-keys: |
-            node-modules-${{ runner.os }}-${{ steps.setup-node.outputs.node-version }}-
-            node-modules-${{ runner.os }}-
-      - name: Yarn install
-        run: yarn install --immutable
+          cache-dependency-path: ${{ inputs.package-manager == 'yarn' && '**/yarn.lock' || '**/pnpm-lock.yaml' }}
+
+      - name: Install dependencies
+        # yamllint disable-line rule:line-length
+        run: ${{ inputs.package-manager == 'yarn' && 'yarn install --immutable' || 'pnpm install --frozen-lockfile' }}
+
       - name: Core lint
         if: ${{ inputs.core-lint }}
-        run: yarn core-lint
+        run: ${{ inputs.package-manager }} core-lint
+
       - name: Web lint
-        run: yarn web-lint
+        run: ${{ inputs.package-manager }} web-lint


### PR DESCRIPTION
## Summary

- Add `package-manager` input to `test-back.yaml` (`poetry` | `uv`, default `poetry`) — uv path uses `astral-sh/setup-uv@v7` with built-in caching
- Add `package-manager` input to `test-web.yaml` and `test-app.yaml` (`yarn` | `pnpm`, default `yarn`) — pnpm path uses `pnpm/action-setup@v4` + `setup-node` built-in cache
- Drop manual `actions/cache` steps in frontend workflows in favor of `setup-node`'s `cache` parameter
- Bump action versions across all workflows (checkout v6, setup-node v6, setup-python v6, etc.)

## Test plan

- [ ] Verify existing consumers (no `package-manager` input) behave identically (poetry + yarn defaults)
- [ ] Test `package-manager: uv` on a backend repo using uv
- [ ] Test `package-manager: pnpm` on a frontend repo using pnpm